### PR TITLE
travis php5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 sudo: required
 env:
   global:
-    - TEST_S3_LOCATION='s3://TRAVISACCESSPHPUNIT:wJalrXUtnFEMI%2FSECRET%2FTRAVISPHPUNIT@us-east-1/?endpoint=http%3A%2F%2F127.0.0.1%3A9999&use_path_style_endpoint=1'
+    - TEST_S3_LOCATION='//TRAVISACCESSPHPUNIT:wJalrXUtnFEMI%2FSECRET%2FTRAVISPHPUNIT@us-east-1/?endpoint=http%3A%2F%2F127.0.0.1%3A9999&use_path_style_endpoint=1'
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ php:
   - 7.1
   - 7.0
   - 5.6
+  - 5.4
 
 before_install:
+  - env
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - wget https://scrutinizer-ci.com/ocular.phar -O ~/.ocular/ocular.phar
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
@@ -33,7 +35,7 @@ install:
   - curl https://bootstrap.pypa.io/get-pip.py >> ~/get-pip.py
   - sudo python ~/get-pip.py
   - sudo pip install yamllint
-  - composer global require "dealerdirect/qa-tools:*"
+  - 'if [[ ${TRAVIS_PHP_VERSION} != "5.4" ]] ; then composer global require "dealerdirect/qa-tools:*" ; fi'
   - "docker run -p 9999:9999 --name minio --rm \
      -e 'MINIO_ACCESS_KEY=TRAVISACCESSPHPUNIT' \
      -e 'MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/TRAVISKEYPHPUNIT' \
@@ -41,20 +43,31 @@ install:
 
 script:
   - composer validate
+  - >
+    if [[ ${TRAVIS_PHP_VERSION} == "5.4" ]] ;  then
+    composer remove  --dev --no-update --no-interaction league/flysystem-aws-s3-v3 ;
+    composer remove  --dev --no-update --no-interaction mhetreramesh/flysystem-backblaze ;
+    composer require --dev --no-update --no-interaction league/flysystem-aws-s3-v2 ;
+    fi
   - composer install -o --prefer-dist --no-scripts
   - >
+    if [[ -e ~/.composer/vendor/bin/jsonlint ]] ; then
     find . -type f -name "*.json" -not -path "./vendor/*" -print0 |
-    xargs -0 --no-run-if-empty -n1 ~/.composer/vendor/bin/jsonlint -c -q
+    xargs -0 --no-run-if-empty -n1 ~/.composer/vendor/bin/jsonlint -c -q ;
+    fi
   - >
     find . -type f -name "*.yml" -not -path "./vendor/*" -print0 |
     xargs -0 --no-run-if-empty -n1 yamllint
   - >
     find . -type f -name "*.xml" -not -path "./vendor/*" -print0 |
     xargs -0 --no-run-if-empty -n1 xmllint --noout --encode utf-8
-  - ~/.composer/vendor/bin/parallel-lint ./src
-  - ~/.composer/vendor/bin/phpcs -p -n ./src
-  - ~/.composer/vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock
+  - 'if [[ -e ~/.composer/vendor/bin/parallel-lint ]] ; then ~/.composer/vendor/bin/parallel-lint ./src ; fi'
+  - 'if [[ -e ~/.composer/vendor/bin/phpcs ]] ; then ~/.composer/vendor/bin/phpcs -p -n ./src ; fi'
+  - 'if [[ -e ~/.composer/vendor/bin/security-checker ]] ; then ~/.composer/vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock ; fi'
   - php -dxdebug.coverage_enable=1 ./vendor/bin/phpunit
 
 after_script:
-  - php ~/.ocular/ocular.phar code-coverage:upload --format=php-clover coverage.xml -vvv
+  - >
+    if [[ ${TRAVIS_PHP_VERSION} == "5.4" || ${TRAVIS_PHP_VERSION} == "7.2" ]] ; then
+    php ~/.ocular/ocular.phar code-coverage:upload --format=php-clover coverage.xml -vvv ;
+    fi

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -17,7 +17,7 @@ trait Endpoint
     public static function endpointToURL($endpoint)
     {
         if (strpos($endpoint, '://') === false && strpos('//', $endpoint) !== 0) {
-            $endpoint = '//'.$endpoint;
+            $endpoint = 'https://'.$endpoint;
         }
 
         $url = \arc\url::url($endpoint);

--- a/tests/Adapter/S3v2Test.php
+++ b/tests/Adapter/S3v2Test.php
@@ -5,23 +5,23 @@ namespace MJRider\FlysystemFactory\Adapter;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @requires PHP 5.6
+ * @requires PHP 5.4
  */
-class S3Test extends TestCase
+class S3v2Test extends TestCase
 {
     protected $root = '';
 
     public function setup()
     {
         $this->root = getenv('TEST_S3_LOCATION');
-        if ( !class_exists('\League\Flysystem\AwsS3v3\AwsS3Adapter') ) {
+        if ( !class_exists('\League\Flysystem\AwsS3v2\AwsS3Adapter') ) {
             $this->markTestSkipped('AWSS3v3 not available, skipping test');
         }
         if ($this->root === false) {
             $this->markTestSkipped('no S3 endpoint available, test skipped');
         }
         if( strpos($this->root,'//') === 0) {
-            $this->root = 's3:'.$this->root;
+            $this->root = 's3v2:'.$this->root;
         }
     }
 
@@ -29,13 +29,13 @@ class S3Test extends TestCase
     {
         $filesystem = \MJRider\FlysystemFactory\create($this->root);
         $this->assertInstanceOf('\League\Flysystem\Filesystem', $filesystem);
-        $this->assertInstanceOf('\League\Flysystem\AwsS3v3\AwsS3Adapter', $filesystem->getAdapter());
+        $this->assertInstanceOf('\League\Flysystem\AwsS3v2\AwsS3Adapter', $filesystem->getAdapter());
     }
 
     public function testS3SubFolder()
     {
         $filesystem = \MJRider\FlysystemFactory\create($this->root);
         $this->assertInstanceOf('\League\Flysystem\Filesystem', $filesystem);
-        $this->assertInstanceOf('\League\Flysystem\AwsS3v3\AwsS3Adapter', $filesystem->getAdapter());
+        $this->assertInstanceOf('\League\Flysystem\AwsS3v2\AwsS3Adapter', $filesystem->getAdapter());
     }
 }


### PR DESCRIPTION
this added php5.4 support to travis. a compromis has been made in installing and using QA tools. Due to php 5.4 compatibility with the installer.

the S3 and the S3v2 tests are mutual exclusive due to requirements, so we rewrite the composer.json on the fly for php 5.4

also included a small bugfix for the endpoint logic, which had a php5.4 specific bug

TEST_S3_LOCATION has now an optional scheme, which is added based on the testcases which would run.
