### PR TITLE
Remove code duplication in S3/S3v2 Adapter

### DIFF
--- a/src/Adapter/Rackspace.php
+++ b/src/Adapter/Rackspace.php
@@ -39,7 +39,7 @@ class Rackspace implements AdapterFactoryInterface
             'tenantId' => urldecode($url->host),
         ];
 
-        $options = (array)$url->query;
+        $options = (array) $url->query;
 
         $container = trim(\arc\path::head($url->path), '/');
         $prefix = ltrim(\arc\path::tail($url->path), '/');

--- a/src/Adapter/S3.php
+++ b/src/Adapter/S3.php
@@ -10,12 +10,10 @@ use \MJRider\FlysystemFactory\Endpoint;
 
 class S3 implements AdapterFactoryInterface
 {
+
     use Endpoint;
 
-    /**
-     * @inheritDoc
-     */
-    public static function create($url)
+    protected static function buildArgs($url)
     {
         $args = [
             'credentials' => [
@@ -31,12 +29,24 @@ class S3 implements AdapterFactoryInterface
             $args[ 'endpoint' ] = self::endpointToURL(urldecode($url->query->endpoint));
         }
 
-        $bucket  = (string) \arc\path::head($url->path);
-        $subpath = (string) \arc\path::tail($url->path);
+        return $args;
+    }
 
+    protected static function buildAdapter($client, $bucket, $subpath)
+    {
+        return new AwsS3Adapter($client, $bucket, $subpath);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function create($url)
+    {
+        $args = static::buildArgs($url);
         $client = S3Client::factory($args);
 
-        $adapter = new AwsS3Adapter($client, $bucket, $subpath);
-        return $adapter;
+        $bucket  = (string) \arc\path::head($url->path);
+        $subpath = (string) \arc\path::tail($url->path);
+        return static::buildAdapter($client, $bucket, $subpath);
     }
 }

--- a/src/Adapter/S3v2.php
+++ b/src/Adapter/S3v2.php
@@ -10,8 +10,8 @@ class S3v2 extends S3
     {
         // modify arguments for use with older S3Client version
         $args = parent::buildArgs($url);
-        $args['key'] = $args['credentials']['key'];
-        $args['secret'] = $args['credentials']['secret'];
+        $args[ 'key' ] = $args[ 'credentials' ][ 'key' ];
+        $args[ 'secret' ] = $args[ 'credentials' ][ 'secret' ];
 
         return $args;
     }

--- a/src/Adapter/S3v2.php
+++ b/src/Adapter/S3v2.php
@@ -2,41 +2,22 @@
 
 namespace MJRider\FlysystemFactory\Adapter;
 
-use \arc\url as url;
-use \arc\path as path;
-use \Aws\S3\S3Client;
 use \League\Flysystem\AwsS3v2\AwsS3Adapter;
-use \MJRider\FlysystemFactory\Endpoint;
 
-class S3v2 implements AdapterFactoryInterface
+class S3v2 extends S3
 {
-    use Endpoint;
-
-    /**
-     * @inheritDoc
-     */
-    public static function create($url)
+    protected static function buildArgs($url)
     {
-        $args = [
-            'key'    => urldecode($url->user),
-            'secret' => urldecode($url->pass),
-            'region' => $url->host,
-            'credentials' => [
-                'key'    => $url->user,
-                'secret' => urldecode($url->pass)
-            ],
-        ];
+        // modify arguments for use with older S3Client version
+        $args = parent::buildArgs($url);
+        $args['key'] = $args['credentials']['key'];
+        $args['secret'] = $args['credentials']['secret'];
 
-        if (isset($url->query->endpoint)) {
-            $args[ 'base_url' ] = self::endpointToURL(urldecode($url->query->endpoint));
-        }
+        return $args;
+    }
 
-        $bucket  = \arc\path::head($url->path);
-        $subpath = \arc\path::tail($url->path);
-
-        $client = S3Client::factory($args);
-
-        $adapter = new AwsS3Adapter($client, $bucket, $subpath);
-        return $adapter;
+    protected static function buildAdapter($client, $bucket, $subpath)
+    {
+        return new AwsS3Adapter($client, $bucket, $subpath);
     }
 }

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -23,6 +23,6 @@ trait Endpoint
         }
 
         $url = \arc\url::url($endpoint);
-        return (string)$url;
+        return (string) $url;
     }
 }


### PR DESCRIPTION
split create function in 2 helpers, which are called with late
static binding to use the v3 or the v2 S3 flysystem adapter and
compensating for the difference between the s3 client versions

also added codestyling fixes from scrutinizer