### PR TITLE
Adds CHANGELOG file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Change Log
+
+## [v0.2.2](https://github.com/mjrider/flysystem-factory/tree/v0.2.2) (2018-01-03)
+[Full Changelog](https://github.com/mjrider/flysystem-factory/compare/v0.2.1...v0.2.2)
+
+**Merged pull requests:**
+
+- Update maintenance state [\#7](https://github.com/mjrider/flysystem-factory/pull/7) ([mjrider](https://github.com/mjrider))
+- add isset check around use\_path\_style\_endpoint [\#6](https://github.com/mjrider/flysystem-factory/pull/6) ([mjrider](https://github.com/mjrider))
+- Remove code duplication in S3/S3v2 Adapter [\#5](https://github.com/mjrider/flysystem-factory/pull/5) ([mjrider](https://github.com/mjrider))
+
+## [v0.2.1](https://github.com/mjrider/flysystem-factory/tree/v0.2.1) (2017-12-09)
+[Full Changelog](https://github.com/mjrider/flysystem-factory/compare/v0.2.0...v0.2.1)
+
+**Merged pull requests:**
+
+- Bugfix: fix issue in url parsing [\#4](https://github.com/mjrider/flysystem-factory/pull/4) ([mjrider](https://github.com/mjrider))
+
+## [v0.2.0](https://github.com/mjrider/flysystem-factory/tree/v0.2.0) (2017-12-07)
+[Full Changelog](https://github.com/mjrider/flysystem-factory/compare/v0.1.0...v0.2.0)
+
+**Merged pull requests:**
+
+- travis php5.4 support [\#3](https://github.com/mjrider/flysystem-factory/pull/3) ([mjrider](https://github.com/mjrider))
+- Mostly code cleanup [\#2](https://github.com/mjrider/flysystem-factory/pull/2) ([Potherca](https://github.com/Potherca))
+- Add php 7.2 and enforce hhvm [\#1](https://github.com/mjrider/flysystem-factory/pull/1) ([mjrider](https://github.com/mjrider))
+
+## [v0.1.0](https://github.com/mjrider/flysystem-factory/tree/v0.1.0) (2017-10-31)


### PR DESCRIPTION
This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator).

I've also taken the liberty of updating [the release notes](https://github.com/mjrider/flysystem-factory/releases) with the same information.

For future releases `github_changelog_generator` should be used to update this document. If needed I can add logic that automates this task.
