### PR TITLE
Fixed path collapsing for S3 and Rackspace

### DIFF
--- a/src/Adapter/Rackspace.php
+++ b/src/Adapter/Rackspace.php
@@ -41,8 +41,9 @@ class Rackspace implements AdapterFactoryInterface
 
         $options = (array) $url->query;
 
-        $container = trim(\arc\path::head($url->path), '/');
-        $prefix = ltrim(\arc\path::tail($url->path), '/');
+        $path = (string) \arc\path::collapse($url->path);
+        $container = trim(\arc\path::head($path), '/');
+        $prefix = ltrim(\arc\path::tail($path), '/');
 
         $client = new OpenStack($auth, $args, $options);
         $store = $client->objectStoreService('swift', $zone);

--- a/src/Adapter/Rackspace.php
+++ b/src/Adapter/Rackspace.php
@@ -41,7 +41,7 @@ class Rackspace implements AdapterFactoryInterface
 
         $options = (array) $url->query;
 
-        $path = (string) \arc\path::collapse($url->path);
+        $path = \arc\path::collapse($url->path);
         $container = trim(\arc\path::head($path), '/');
         $prefix = ltrim(\arc\path::tail($path), '/');
 

--- a/src/Adapter/S3.php
+++ b/src/Adapter/S3.php
@@ -49,7 +49,7 @@ class S3 implements AdapterFactoryInterface
         $args = static::buildArgs($url);
         $client = S3Client::factory($args);
 
-        $path = (string) \arc\path::collapse($url->path);
+        $path = \arc\path::collapse($url->path);
         $bucket  = (string) \arc\path::head($path);
         $subpath = (string) \arc\path::tail($path);
         return static::buildAdapter($client, $bucket, $subpath);

--- a/src/Adapter/S3.php
+++ b/src/Adapter/S3.php
@@ -49,8 +49,9 @@ class S3 implements AdapterFactoryInterface
         $args = static::buildArgs($url);
         $client = S3Client::factory($args);
 
-        $bucket  = (string) \arc\path::head($url->path);
-        $subpath = (string) \arc\path::tail($url->path);
+        $path = (string) \arc\path::collapse($url->path);
+        $bucket  = (string) \arc\path::head($path);
+        $subpath = (string) \arc\path::tail($path);
         return static::buildAdapter($client, $bucket, $subpath);
     }
 }


### PR DESCRIPTION
When there is no trailing slash in the S3 url like in the example:
```
s3://accesstoken:secretkey@region/bucketname
```

The subpath will be `/bucketname` when we expect it to be `/` so the connection will not be established with amazon. This PR will fix this.
